### PR TITLE
Add admin-panel label in charts PR

### DIFF
--- a/ci/tasks/open-charts-pr.sh
+++ b/ci/tasks/open-charts-pr.sh
@@ -29,4 +29,5 @@ gh pr create \
   --body-file ../body.md \
   --base ${BRANCH} \
   --head ${BOT_BRANCH} \
-  --label galoybot
+  --label galoybot \
+  --label admin-panel


### PR DESCRIPTION
The label `admin-panel` has been added to the charts repo.