### PR TITLE
ci: releasing source code

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -128,6 +128,8 @@ jobs:
             trigger: true
             passed: [ release ]
           - get: version
+            trigger: true
+            passed: [ release ]
           - get: charts-repo
             params: { skip_download: true }
           - get: pipeline-tasks

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -32,6 +32,7 @@ groups:
   - name: admin-panel
     jobs:
       - build-edge-image
+      - release
       - bump-image-in-chart
 
 jobs:
@@ -181,6 +182,13 @@ resources:
       uri: #@ data.values.meta_release_git_uri
       branch: #@ data.values.meta_release_git_version_branch
       private_key: #@ data.values.github_private_key
+
+  - name: gh-release
+    type: github-release
+    source:
+      owner: #@ data.values.gh_org
+      repository: #@ data.values.gh_repository
+      access_token: #@ data.values.github_token
 
   - name: meta-release
     type: git

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,6 +4,10 @@
 #@   return data.values.docker_registry + "/galoy-app-pipeline"
 #@ end
 
+#@ def release_pipeline_image():
+#@   return data.values.docker_registry + "/release-pipeline"
+#@ end
+
 #@ def admin_panel_image():
 #@   return data.values.docker_registry + "/admin-panel"
 #@ end
@@ -14,6 +18,14 @@ source:
   username: #@ data.values.docker_registry_user
   password: #@ data.values.docker_registry_password
   repository: #@ pipeline_image()
+#@ end
+
+#@ def release_task_image_config():
+type: registry-image
+source:
+  username: #@ data.values.docker_registry_user
+  password: #@ data.values.docker_registry_password
+  repository: #@ release_pipeline_image()
 #@ end
 
 groups:
@@ -59,18 +71,60 @@ jobs:
       - put: edge-image
         params:
           image: image/image.tar
+  
+  - name: release
+    plan:
+    - in_parallel:
+      - get: repo
+        trigger: true
+        passed: [ build-edge-image ]
+      - get: edge-image
+        params:
+          format: oci
+      - get: meta-release
+      - get: version
+      - get: charts-repo
+    - task: prep-release
+      config:
+        platform: linux
+        image_resource: #@ release_task_image_config()
+        inputs:
+        - name: repo
+        - name: edge-image
+        - name: meta-release
+        - name: version
+        - name: charts-repo
+        outputs:
+        - name: version
+        - name: artifacts
+        params:
+          CHART: admin-panel
+        run:
+          path: meta-release/ci/tasks/prep-release-src.sh
+    - put: edge-image
+      params:
+        image: edge-image/image.tar
+        additional_tags: artifacts/gh-release-tag
+    - put: gh-release
+      params:
+        name: artifacts/gh-release-name
+        tag: artifacts/gh-release-tag
+        body: artifacts/gh-release-notes.md
+    - put: version
+      params:
+        file: version/version
 
   - name: bump-image-in-chart
     plan:
       - in_parallel:
           - get: edge-image
             trigger: true
-            passed: [build-edge-image]
+            passed: [ release ]
             params: { skip_download: true }
           - get: repo
             trigger: true
-            passed:
-              - build-edge-image
+            passed: [ release ]
+          - get: version
           - get: charts-repo
             params: { skip_download: true }
           - get: pipeline-tasks
@@ -83,6 +137,7 @@ jobs:
             - name: edge-image
             - name: pipeline-tasks
             - name: charts-repo
+            - name: version
           outputs:
             - name: charts-repo
           params:
@@ -115,6 +170,23 @@ resources:
       ignore_paths: ["ci/*[^md]"]
       uri: #@ data.values.git_uri
       branch: #@ data.values.git_branch
+      private_key: #@ data.values.github_private_key
+
+  - name: version
+    type: semver
+    source:
+      initial_version: 0.0.0
+      driver: git
+      file: admin-panel-src-version
+      uri: #@ data.values.meta_release_git_uri
+      branch: #@ data.values.meta_release_git_version_branch
+      private_key: #@ data.values.github_private_key
+
+  - name: meta-release
+    type: git
+    source:
+      uri: #@ data.values.meta_release_git_uri
+      branch: #@ data.values.meta_release_git_branch
       private_key: #@ data.values.github_private_key
 
   - name: charts-repo-bot-branch

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -80,7 +80,6 @@ jobs:
         trigger: true
         passed: [ build-edge-image ]
       - get: edge-image
-        trigger: true
         passed: [ build-edge-image ]
         params:
           format: oci
@@ -121,7 +120,6 @@ jobs:
     plan:
       - in_parallel:
           - get: edge-image
-            trigger: true
             passed: [ release ]
             params: { skip_download: true }
           - get: repo

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -80,6 +80,8 @@ jobs:
         trigger: true
         passed: [ build-edge-image ]
       - get: edge-image
+        trigger: true
+        passed: [ build-edge-image ]
         params:
           format: oci
       - get: meta-release

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -103,7 +103,7 @@ jobs:
           CHART: admin-panel
         run:
           path: meta-release/ci/tasks/prep-release-src.sh
-    - put: edge-image
+    - put: versioned-image
       params:
         image: edge-image/image.tar
         additional_tags: artifacts/gh-release-tag
@@ -217,6 +217,13 @@ resources:
     type: registry-image
     source:
       tag: edge
+      username: #@ data.values.docker_registry_user
+      password: #@ data.values.docker_registry_password
+      repository: #@ admin_panel_image()
+
+  - name: versioned-image
+    type: registry-image
+    source:
       username: #@ data.values.docker_registry_user
       password: #@ data.values.docker_registry_password
       repository: #@ admin_panel_image()

--- a/ci/tasks/bump-image-digest.sh
+++ b/ci/tasks/bump-image-digest.sh
@@ -4,11 +4,13 @@ set -eu
 
 export digest=$(cat ./edge-image/digest)
 export ref=$(cat ./repo/.git/short_ref)
+export app_version=$(cat version/version)
 
 pushd charts-repo
 
 yq -i e '.image.digest = strenv(digest)' ./charts/admin-panel/values.yaml
 yq -i e '.image.git_ref = strenv(ref)' ./charts/admin-panel/values.yaml
+yq -i e '.appVersion = strenv(app_version)' ./charts/admin-panel/Chart.yaml
 
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@galoy.io"

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -11,3 +11,6 @@ docker_registry: us.gcr.io/galoy-org
 docker_registry_user: ((docker-creds.username))
 docker_registry_password: ((docker-creds.password))
 docker_host_ip: ((staging-ssh.docker_host_ip))
+meta_release_git_uri: git@github.com:GaloyMoney/meta-release.git
+meta_release_git_branch: main
+meta_release_git_version_branch: version

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -14,3 +14,5 @@ docker_host_ip: ((staging-ssh.docker_host_ip))
 meta_release_git_uri: git@github.com:GaloyMoney/meta-release.git
 meta_release_git_branch: main
 meta_release_git_version_branch: version
+gh_org: GaloyMoney
+gh_repository: admin-panel


### PR DESCRIPTION
This PR adds Source code releasing. It uses a script from `meta-release` [here](https://github.com/GaloyMoney/meta-release/blob/main/ci/tasks/prep-release-src.sh).