### PR TITLE
fix: count decimals issues with integer values

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,6 +29,7 @@ export const formatNumber = (val) =>
   countDecimals(val) > 8 ? Number(val).toFixed(8) : val
 
 const countDecimals = (val) => {
-  if (Math.floor(val.valueOf()) === val.valueOf()) return 0
-  return val.toString().split(".")[1].length || 0
+  const value = Number(val)
+  if (Math.floor(value.valueOf()) === value.valueOf()) return 0
+  return value.toString().split(".")[1].length || 0
 }


### PR DESCRIPTION
Fix crash in transactions view for queries that include usd transactions

you can reproduce the error in staging with this hash `9e7b8c7c98d2e6f845fdd3ff6abbf24e5046dec0a6c94025addae7bbb590a630`