### PR TITLE
feat: kratos cookie auth config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ With a default installation, Admin Panel can be accessed with `admin.domain.com`
 
 ## How to run this repo locally?
 
-This project uses Next.js, to run it locally, you need to set the following environment variable (in a `.env.local` file):
+This project uses Next.js, to run it locally, you need to set the following environment variables (in a `.env.local` file):
 
 ```
-export NEXT_PUBLIC_GRAPHQL_URL=https://admin-api.staging.galoy.io/graphql
+NEXT_PUBLIC_GRAPHQL_URL=https://admin-api.staging.galoy.io/graphql
+NEXT_PUBLIC_GALOY_AUTH_ENDPOINT=https://admin-api.staging.galoy.io/auth
 ```
 
-Then, nn the project directory, you can run:
+Then, in the project directory, you can run:
 
 ```
 yarn install

--- a/components/auth-code-form.tsx
+++ b/components/auth-code-form.tsx
@@ -29,7 +29,7 @@ const AuthCodeForm: React.FC<{ phoneNumber: string }> = ({ phoneNumber }) => {
         credentials: "include",
       })
       if (loginResp instanceof Error) return reportError(loginResp)
-      window.sessionStorage.setItem("token", "fakeToken")
+      window.sessionStorage.setItem("token", "loggedInWithCookie")
       router.push("/account")
     } catch (e) {
       return reportError({

--- a/components/auth-code-form.tsx
+++ b/components/auth-code-form.tsx
@@ -1,41 +1,42 @@
 "use client"
 
 import { useState } from "react"
-import { useMutation } from "@apollo/client"
 
 import { validAuthCode, reportError } from "../utils"
 import { useRouter } from "next/navigation"
-import { LOGIN } from "../graphql/mutations"
+import config from "../config"
 
 const AuthCodeForm: React.FC<{ phoneNumber: string }> = ({ phoneNumber }) => {
   const router = useRouter()
   const [otp, setOtp] = useState("")
-  const [login, { loading: userLoginLoading }] = useMutation(LOGIN)
+  const [userLoginLoading, setUserLoginLoading] = useState(false)
 
   const submitOtp: React.FormEventHandler<HTMLFormElement> = async (event) => {
     event.preventDefault()
-
-    const { errors: loginErrors, data } = await login({
-      variables: { input: { phone: phoneNumber, code: otp } },
+    const raw = JSON.stringify({
+      phoneNumber,
+      authCode: otp,
     })
-
-    if (loginErrors) {
-      return reportError(loginErrors[0])
-    }
-
-    if (data?.userLogin) {
-      const { errors, authToken } = data.userLogin
-
-      if (errors.length > 0) {
-        return reportError(errors[0])
-      }
-
-      if (authToken) {
-        window.sessionStorage.setItem("token", authToken)
-        router.push("/account")
-      } else {
-        alert("Could not execute operation")
-      }
+    setUserLoginLoading(true)
+    try {
+      const loginResp = await fetch(`${config().GALOY_AUTH_ENDPOINT}/login`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: raw,
+        redirect: "follow",
+        credentials: "include",
+      })
+      if (loginResp instanceof Error) return reportError(loginResp)
+      window.sessionStorage.setItem("token", "fakeToken")
+      router.push("/account")
+    } catch (e) {
+      return reportError({
+        message: "Error logging in",
+      })
+    } finally {
+      setUserLoginLoading(false)
     }
   }
 

--- a/config/index.ts
+++ b/config/index.ts
@@ -1,5 +1,6 @@
 const config = () => {
   const isBrowser = typeof window !== "undefined"
+  const GALOY_AUTH_ENDPOINT = process.env.NEXT_PUBLIC_GALOY_AUTH_ENDPOINT
 
   if (isBrowser) {
     return window.__NEXT_DATA__.props.pageProps.publicConfig
@@ -7,6 +8,7 @@ const config = () => {
 
   return {
     GRAPHQL_URL: process.env.NEXT_PUBLIC_GRAPHQL_URL,
+    GALOY_AUTH_ENDPOINT,
   }
 }
 


### PR DESCRIPTION
This PR updates the code to use cookies instead of session tokens.

- [x] * It requires this galoy backend PR to be merged first https://github.com/GaloyMoney/galoy/pull/2254
* It also requires the Charts repo to add new env var `NEXT_PUBLIC_GALOY_AUTH_ENDPOINT=http://localhost:4002/auth
`

cc: @krtk6160 